### PR TITLE
Remove obsolete lints from the build specification.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 
 #![forbid(missing_docs, warnings)]
 #![deny(deprecated, improper_ctypes, non_shorthand_field_patterns, overflowing_literals,
-    plugin_as_library, private_no_mangle_fns, private_no_mangle_statics, stable_features,
+    stable_features,
     unconditional_recursion, unknown_lints, unused, unused_allocation, unused_attributes,
     unused_comparisons, unused_features, unused_parens, while_true)]
 #![warn(trivial_casts, trivial_numeric_casts, unused, unused_extern_crates, unused_import_braces,


### PR DESCRIPTION
The library has a number of explicit warning switches, some
of which are no longer supported, preventing the build from
completing.

Remove lints from the `deny` list which do not work in
rustc 1.48.0 so the crate compiles on the latest stable
toolchain.