### PR TITLE
Fix build on non-x86 platforms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,10 @@ fn calculate_t(jde: f64) -> f64 {
 /// Calculates the given variable.
 #[inline]
 fn calculate_var(t: f64, a: &[f64], b: &[f64], c: &[f64]) -> f64 {
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(feature = "no_std")
+    ))]
     #[allow(unsafe_code)]
     {
         if is_x86_feature_detected!("avx") {
@@ -289,7 +292,10 @@ fn calculate_var(t: f64, a: &[f64], b: &[f64], c: &[f64]) -> f64 {
         }
     }
 
-    #[cfg(feature = "no_std")]
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        feature = "no_std"
+    ))]
     {
         calculate_var_fallback(t, a, b, c)
     }


### PR DESCRIPTION
Account for non-intel architectures when compiling the dispatch
to avx or fallback implementations. The cfg attribute on the
call site must be the same as the attribute governing compilation
of the function definition, and the fallback must be enabled for
the opposite condition.

Previously the fallback was only enabled for the no_std case.

Restores positive `cargo +nightly test` run on my aarch64 laptop.